### PR TITLE
植物図鑑の修正

### DIFF
--- a/codes/static/js/choice_color.js
+++ b/codes/static/js/choice_color.js
@@ -11,7 +11,7 @@ function random_choice(color_seed) {
     var imageNo = 0
     if (color_seed == "rose") {
         // 4色　赤、黄色、オレンジ、白
-        var images = ['https://firebasestorage.googleapis.com/v0/b/grow-plant-webapp.appspot.com/o/rose3.png?alt=media&token=691c5682-0ddb-4a38-8197-09d143ef2040', 'https://firebasestorage.googleapis.com/v0/b/grow-plant-webapp.appspot.com/o/rose3_yellow.png?alt=media&token=5dcd2231-15cb-4776-a46f-1e1caf1e2a21', 'https://firebasestorage.googleapis.com/v0/b/grow-plant-webapp.appspot.com/o/rose3_white.png?alt=media&token=dac14c21-019b-4027-9a04-3c8d848a72dd', 'https://firebasestorage.googleapis.com/v0/b/grow-plant-webapp.appspot.com/o/rose3_orange.png?alt=media&token=3a7482f3-0346-44b9-b322-6b50a5011a8a'];
+        var images = ['https://firebasestorage.googleapis.com/v0/b/grow-plant-webapp.appspot.com/o/rose3.png?alt=media&token=691c5682-0ddb-4a38-8197-09d143ef2040', 'https://firebasestorage.googleapis.com/v0/b/grow-plant-webapp.appspot.com/o/rose3_yellow.png?alt=media&token=5dcd2231-15cb-4776-a46f-1e1caf1e2a21','https://firebasestorage.googleapis.com/v0/b/grow-plant-webapp.appspot.com/o/rose3_orange.png?alt=media&token=3a7482f3-0346-44b9-b322-6b50a5011a8a', 'https://firebasestorage.googleapis.com/v0/b/grow-plant-webapp.appspot.com/o/rose3_white.png?alt=media&token=dac14c21-019b-4027-9a04-3c8d848a72dd'];
         if (random < 35) { 
             imageNo = 0;
             color_variation_f[0][0] = true; 

--- a/codes/static/js/micromodal.js
+++ b/codes/static/js/micromodal.js
@@ -117,16 +117,21 @@ var picbook = document.getElementById('pic-book');
 picbook_btn.addEventListener('click', function() {
     picbook.classList.add('is-show');
     get_explanation("sunflower") // 図鑑起動時の説明を取得（図鑑を開いたときは必ずヒマワリのページからなので"sunflower"の説明を取得）
+    document.getElementById("pic-book-pname").textContent = "ヒマワリ";
 })
 
 
 var blackBg = document.getElementById('js-black-bg-picbook');
 blackBg.addEventListener('click', function() {
     picbook.classList.remove('is-show');
+    index = 0;
+    //document.getElementById("pic-book-pname").textContent = plant_name_jp[0];
 }) 
 var picbook_close_btn = document.getElementById('js-close-picbook');
 picbook_close_btn.addEventListener('click', function() {
     picbook.classList.remove('is-show');
+    index = 0;
+    //document.getElementById("pic-book-pname").textContent = plant_name_jp[0];
 })
 
 var pre_btn = document.getElementById('left-arrow-img');


### PR DESCRIPTION
バラのオレンジと白の画像（URL）が逆になっていた
図鑑を再度開いたときにヒマワリからスタートするようにした(説明文と色がヒマワリスタートになっていたので合わせました)
